### PR TITLE
refactor: rename repo name to play-with-vue

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,24 +1,33 @@
-# vue-build-repro
+# play-with-vue
+
+This repo is for demonstrating all things related to Vue.js.
+
+**Note:** The repo does not involve Vue 3, mainly because currently Vue.js 3 is still under `next` release tag). For Vue 3 demos, see: [rianma/play-with-vue-3](https://github.com/rianma/play-with-vue-3)
 
 ## Project setup
-```
+
+```bash
 npm install
 ```
 
 ### Compiles and hot-reloads for development
-```
+
+```bash
 npm run serve
 ```
 
 ### Compiles and minifies for production
-```
+
+```bash
 npm run build
 ```
 
 ### Lints and fixes files
-```
+
+```bash
 npm run lint
 ```
 
 ### Customize configuration
+
 See [Configuration Reference](https://cli.vuejs.org/config/).

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "fiddle-with-vue",
+  "name": "play-with-vue",
   "version": "0.1.0",
   "lockfileVersion": 2,
   "requires": true,

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "fiddle-with-vue",
+  "name": "play-with-vue",
   "version": "0.1.0",
   "private": true,
   "scripts": {


### PR DESCRIPTION
Rename the repo name to `play-with-vue`, and change the corresponding package name.